### PR TITLE
Fixing access specifiers on exceptions, removed unused exception

### DIFF
--- a/include/libdbc/exceptions/error.hpp
+++ b/include/libdbc/exceptions/error.hpp
@@ -6,32 +6,17 @@
 namespace libdbc {
 
 	class exception : public std::exception {
+	public:
 		const char * what() const throw() {
 			return "libdbc exception occurred";
 		}
 	};
 
 	class validity_error : public exception {
+	public:
 		const char * what() const throw() {
-			return "Invalid DBC file...";
+			return "Invalid DBC file";
 		}
-	};
-
-	class header_error : public validity_error {
-		header_error(const char* line, const char* expected, const char * file) :
-			line(line), expected(expected), file(file) {}
-
-		const char * what() const throw() {
-			std::ostringstream os;
-			os << "Issue with the header line ( " << line << " ) in file ( ";
-			os << file << " ). Expected to find: " << expected;
-			return os.str().c_str();
-		}
-
-	private:
-		const char * line;
-		const char * expected;
-		const char * file;
 	};
 
 } // libdbc

--- a/test/test_dbc.cpp
+++ b/test/test_dbc.cpp
@@ -22,6 +22,15 @@ TEST_CASE("Testing dbc file loading error issues", "[fileio][error]") {
 		// very well standardized for now we ignore this type of error.
 		CHECK_NOTHROW(parser->parse_file(MISSING_NEW_SYMBOLS_DBC_FILE));
 	}
+
+	SECTION("Verify that what() method is accessible for all exceptions", "[error]")
+	{
+		auto generic_error = libdbc::exception();
+		REQUIRE(generic_error.what() == "libdbc exception occurred");
+
+		auto validity_check = libdbc::validity_error();
+		REQUIRE(validity_check.what() == "Invalid DBC file");
+	}
 }
 
 TEST_CASE("Testing dbc file loading", "[fileio]") {


### PR DESCRIPTION
Fixing the public specifier issue on the exceptions. Removed the unused `header_error` not sure why that was there.