### PR TITLE
Fix flaky float comparison in aarch64 tests

### DIFF
--- a/test/test_parse_message.cpp
+++ b/test/test_parse_message.cpp
@@ -50,7 +50,7 @@ TEST_CASE("Parse Message Big Number not aligned little endian") {
 		CHECK(refData.size() == 7);
 		CHECK(out_values.size() == refData.size());
 		for (size_t i = 0; i < refData.size(); i++) {
-			CHECK(out_values.at(i) == refData.at(i));
+			CHECK(out_values.at(i) == Catch::Approx(refData.at(i)).margin(1e-9));
 		}
 	}
 
@@ -61,7 +61,7 @@ TEST_CASE("Parse Message Big Number not aligned little endian") {
 		CHECK(refData.size() == 7);
 		CHECK(out_values.size() == refData.size());
 		for (size_t i = 0; i < refData.size(); i++) {
-			CHECK(out_values.at(i) == refData.at(i));
+			CHECK(out_values.at(i) == Catch::Approx(refData.at(i)).margin(1e-9));
 		}
 	}
 
@@ -72,7 +72,7 @@ TEST_CASE("Parse Message Big Number not aligned little endian") {
 		CHECK(refData.size() == 7);
 		CHECK(out_values.size() == refData.size());
 		for (size_t i = 0; i < refData.size(); i++) {
-			CHECK(out_values.at(i) == refData.at(i));
+			CHECK(out_values.at(i) == Catch::Approx(refData.at(i)).margin(1e-9));
 		}
 	}
 }


### PR DESCRIPTION
The three `CHECK(out_values.at(i) == refData.at(i))` comparisons in `test_parse_message.cpp` (Big Number not aligned little endian test) use exact float equality, which fails on aarch64 due to floating-point rounding differences. Switched to `Catch::Approx(refData.at(i)).margin(1e-9)` for tolerance-based comparison.

Fixes CI failure seen here: https://github.com/AhmedAmrNabil/nixpkgs-review-gha/actions/runs/32652224845/job/97225537584#step:6:647